### PR TITLE
fix(require): missing reference in Function body

### DIFF
--- a/lib/couchdb-ddoc-test.js
+++ b/lib/couchdb-ddoc-test.js
@@ -45,8 +45,8 @@ module.exports = function DDocTest(options) {
   var body = "return (" + src + ");";
   /* jshint evil: true */
   // Add globals to design view.
-  var makeFn = new Function("emit", "log", "getRow", "send", "start", body);
-  var fn = makeFn(emit, log, getRow, send, start);
+  var fn = new Function("require", "emit", "log", "getRow", "send", "start", body).bind({})(
+    require, emit, log, getRow, send, start);
 
   return {
     runMap: function() {


### PR DESCRIPTION
inside of the function created with the `new Function` constructor,
the reference to `require` was missing.

see answer to http://stackoverflow.com/questions/12263104/why-is-context-inside-non-interactive-function-object-different-in-node-js