### PR TITLE
fix(require): missing reference in Function body

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ assert.equals(result, fixture);
 
 ```
 
+fixture can have `null` value.
+
 ### available test functions
 
  CouchDB function                                                                               | available test functions
@@ -23,7 +25,7 @@ assert.equals(result, fixture);
 [mapfun](http://docs.couchdb.org/en/latest/couchapp/ddocs.html#map-functions)(doc)              | `runMap()`  *see note* *
 [filterfun](http://docs.couchdb.org/en/latest/couchapp/ddocs.html#filter-functions)(doc, req)   | `runFilter(req)` *see note* *
 [listfun](http://docs.couchdb.org/en/latest/couchapp/ddocs.html#list-functions)(head, req)      | `runList(head, req)`
-[updatefun](http://docs.couchdb.org/en/latest/couchapp/ddocs.html#update-functions)(doc, req)      | `runUpdate(head, req)`
+[updatefun](http://docs.couchdb.org/en/latest/couchapp/ddocs.html#update-functions)(doc, req)      | `runUpdate(doc, req)`
 
 * the missing `doc` param is obtained from the provided **fixture** and passed internally to the tested function.
 

--- a/lib/couchdb-ddoc-test.js
+++ b/lib/couchdb-ddoc-test.js
@@ -3,7 +3,7 @@ var loadFun = require('./load-function');
 module.exports = function DDocTest(options) {
   options = options || {};
 
-  if (!options.fixture) {
+  if (options.fixture !== null && !options.fixture) {
     throw new Error('missing options.fixture argument');
   }
 

--- a/test/test.js
+++ b/test/test.js
@@ -38,12 +38,18 @@ assert.equal(result, true);
 // should bail if fixture is missing
 try {
   var test2 = new DDocTest({
-    src: 'test/fixture/mapjs'
+    src: 'test/fixtures/mapjs'
   });
   assert(false); // should not happen
 } catch(e) {
   assert.equal(e.message, 'missing options.fixture argument');
 }
+
+var test2 = new DDocTest({
+  fixture: null,
+  src: 'test/fixtures/update.js'
+});
+assert(true); // should pass
 
 // should bail if src is missing
 try {


### PR DESCRIPTION
inside of the function created with the `new Function` constructor,
the reference to `require` was missing.

see answer to http://stackoverflow.com/questions/12263104/why-is-context-inside-non-interactive-function-object-different-in-node-js